### PR TITLE
fix: localize the new tab page title (#118)

### DIFF
--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -29,6 +29,9 @@
   "mainUiScaleLabel": {
     "message": "Main UI Scale"
   },
+  "newTabTitle": {
+    "message": "New Tab"
+  },
   "tabNameLabel": {
     "message": "Tab Name"
   },

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta charset="UTF-8" />
     <script src="/scripts/theme-loader.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>New Tab</title>
+    <title data-i18n="newTabTitle">New Tab</title>
 
     <link rel="preconnect" href="https://api.open-meteo.com" />
     <link rel="preconnect" href="https://geocoding-api.open-meteo.com" />

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -63,6 +63,12 @@ function applyToDOM(messages) {
         element.placeholder = translation;
       } else if (element.tagName === 'OPTION') {
         element.textContent = translation;
+      } else if (element.tagName === 'TITLE') {
+        // Localize the browser tab title, but never override a user-defined
+        // custom tab name (handled in tab-customization).
+        if (!localStorage.getItem('tabName')) {
+          document.title = translation;
+        }
       } else {
         element.innerHTML = translation;
       }

--- a/src/core/boot/main.ts
+++ b/src/core/boot/main.ts
@@ -477,7 +477,8 @@ async function bootInteractive(): Promise<void> {
       localStorage.removeItem('tabName');
       localStorage.removeItem('tabFavicon');
       localStorage.removeItem('tabIcon');
-      document.title = 'Fluent New Tab';
+      document.title =
+        (window as any).getTranslation?.('newTabTitle') || 'New Tab';
 
       const link = document.querySelector(
         "link[rel~='icon']",

--- a/src/core/ui/tab-customization.ts
+++ b/src/core/ui/tab-customization.ts
@@ -33,8 +33,10 @@ export function initTabCustomization(): void {
       const target = e.target as HTMLInputElement;
       if (!target) return;
       localStorage.setItem('tabName', target.value);
+      const defaultTitle =
+        (window as any).getTranslation?.('newTabTitle') || 'New Tab';
       document.title =
-        target.value.trim() === '' ? 'Fluent New Tab' : target.value;
+        target.value.trim() === '' ? defaultTitle : target.value;
     });
   }
 


### PR DESCRIPTION
## Summary

- The browser tab title was hardcoded to the English "New Tab" in `index.html` and never connected to the i18n system, so it stayed in English regardless of the selected interface language.
- Root cause: `applyToDOM` only processes `data-i18n` elements and `<title>` had none; the `initTabCustomization` path only set `document.title` for user-defined custom names, leaving the default case always English.

## Changes

- `index.html`: added `data-i18n="newTabTitle"` to the `<title>` element.
- `public/scripts/i18n.js`: `applyToDOM` now sets `document.title` for the `TITLE` tag, skipping it when a custom `tabName` is stored so the user's preference wins.
- `_locales/en_US/messages.json`: added `newTabTitle` source string (en_US Crowdin source only — no translated locale files edited, per `TRANSLATING.md`).
- `src/core/ui/tab-customization.ts`: replaced hardcoded `'Fluent New Tab'` fallback with localized default.
- `src/core/boot/main.ts`: same replacement in `resetAppearanceFeatures`.

Fixes #118